### PR TITLE
Add a class implementing DNS Discovery

### DIFF
--- a/src/SrvDiscoverer.php
+++ b/src/SrvDiscoverer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace ActiveCollab\Etcd;
+
+/**
+ * @package ActiveCollab\Etcd
+ */
+class SrvDiscoverer
+{
+
+    /**
+     * @var string
+     */
+    private $domain;
+
+    /**
+     * @param string $domain
+     */
+    public function __construct($domain)
+    {
+        $this->domain = $domain;
+    }
+
+    /**
+     * Fetch the servers with a DNS SRV request
+     *
+     * @return array
+     */
+    public function getServers()
+    {
+        $records = dns_get_record($this->domain, DNS_SRV);
+        $result = [];
+        foreach ($records as $record) {
+            $result[] = [
+                'target' => $record['target'],
+                'port' => $record['port'],
+                'pri' => $record['pri'],
+                'weight' => $record['weight'],
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Pick a server according to the priority fields.
+     * Note that weight is currently ignored.
+     *
+     * @param array $servers from getServers
+     * @return array|bool
+     */
+    public function pickServer(array $servers)
+    {
+        if (!$servers) {
+            return false;
+        }
+        $by_prio = [];
+        foreach ($servers as $server) {
+            $by_prio[$server['pri']][] = $server;
+        }
+
+        $min = min(array_keys($by_prio));
+        if (count($by_prio[$min]) == 1) {
+            return $by_prio[$min][0];
+        } else {
+            // Choose randomly
+            $rand = mt_rand(0, count($by_prio[$min])-1);
+            return $by_prio[$min][$rand];
+        }
+    }
+}


### PR DESCRIPTION
etcd supports using SRV records to help clients discover the etcd
cluster:
<https://coreos.com/etcd/docs/latest/v2/clustering.html#dns-discovery>.

This implements a basic class to get a list of servers in the cluster,
and a helper function to pick one in accordance with RFC 2782.


I tried to follow the existing code style, but might have missed something. We are currently [evaluating and planning](https://phabricator.wikimedia.org/T156924) to use etcd for configuring parts of MediaWiki on Wikimedia wikis, and one of our requirements is being able to discover individual etcd servers using the DNS discovery. And while this doesn't need to be part of this library, I think it would make a nice addition.